### PR TITLE
Use nextjs config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-NODE_ENV=development
-API_URL=https://api.csgonades.com
-ADS_ENABLED=true

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+NODE_ENV=development
+API_URL=https://api.csgonades.com
+ADS_ENABLED=true

--- a/.env.defaults
+++ b/.env.defaults
@@ -1,0 +1,3 @@
+NODE_ENV=production
+API_URL=https://api.csgonades.com
+ADS_ENABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .next
 dist
 yarn-error.log
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 yarn-error.log
 .idea
+.env

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,17 @@ const base = {
   images: {
     domains: ["storage.googleapis.com"],
   },
+  productionBrowserSourceMaps: true,
+  serverRuntimeConfig: {
+    // Will only be available on the server side
+    mySecret: 'secret',
+    secondSecret: process.env.SECOND_SECRET, // Pass through env variables
+  },
+  publicRuntimeConfig: {
+    // Will be available on both server and client
+    apiUrl: process.env.API_URL,
+    adsEnabled: process.env.ADS_ENABLED
+  },
 };
 
 module.exports = withBundleAnalyzer(base);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Mellet Solbakk",
   "license": "MIT",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start -p $PORT",
     "analyze": "cross-env ANALYZE=true next build",

--- a/src/admin/data/AuiditApi.ts
+++ b/src/admin/data/AuiditApi.ts
@@ -5,7 +5,7 @@ import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import { Config } from "../../constants/Constants";
 import getConfig from "next/config";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 export class AuditApi {
   static async fetchAuditEvents(token: string): AppResult<AuditDto[]> {

--- a/src/admin/data/AuiditApi.ts
+++ b/src/admin/data/AuiditApi.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import { ok } from "neverthrow";
 import { AuditDto } from "../models/AuditEvent";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
-import { Config } from "../../constants/Constants";
 import getConfig from "next/config";
 
 const config = getConfig()?.publicRuntimeConfig;

--- a/src/admin/data/AuiditApi.ts
+++ b/src/admin/data/AuiditApi.ts
@@ -3,11 +3,14 @@ import { ok } from "neverthrow";
 import { AuditDto } from "../models/AuditEvent";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import { Config } from "../../constants/Constants";
+import getConfig from "next/config";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 export class AuditApi {
   static async fetchAuditEvents(token: string): AppResult<AuditDto[]> {
     try {
-      const response = await axios.get<AuditDto[]>(`${Config.API_URL}/audits`, {
+      const response = await axios.get<AuditDto[]>(`${config.apiUrl}/audits`, {
         headers: { Authorization: token },
       });
 

--- a/src/contact/data/ContactApi.ts
+++ b/src/contact/data/ContactApi.ts
@@ -5,7 +5,7 @@ import { AddConctactDTO, ContactDTO } from "../models/ContactDTOs";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 export class ContactApi {
   static async sendMessage(message: AddConctactDTO): AppResult<boolean> {

--- a/src/contact/data/ContactApi.ts
+++ b/src/contact/data/ContactApi.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { AddConctactDTO, ContactDTO } from "../models/ContactDTOs";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";

--- a/src/contact/data/ContactApi.ts
+++ b/src/contact/data/ContactApi.ts
@@ -3,11 +3,14 @@ import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
 import { AddConctactDTO, ContactDTO } from "../models/ContactDTOs";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+import getConfig from "next/config";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 export class ContactApi {
   static async sendMessage(message: AddConctactDTO): AppResult<boolean> {
     try {
-      await axios.post(`${Config.API_URL}/contact`, message);
+      await axios.post(`${config.apiUrl}/contact`, message);
       return ok(true);
     } catch (error) {
       return extractApiError(error);
@@ -17,7 +20,7 @@ export class ContactApi {
   static async fetchContactMessages(token: string): AppResult<ContactDTO[]> {
     try {
       const response = await axios.get<ContactDTO[]>(
-        `${Config.API_URL}/contact`,
+        `${config.apiUrl}/contact`,
         {
           headers: { Authorization: token },
         }

--- a/src/core/api/StatsApi.ts
+++ b/src/core/api/StatsApi.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+import getConfig from "next/config";
 
 export type SiteStats = {
   ezoicEnabled: boolean;
@@ -10,10 +10,12 @@ export type SiteStats = {
   numUsers: number;
 };
 
+const { config } = getConfig();
+
 export class StatsApi {
   static async getStats(): AppResult<SiteStats> {
     try {
-      const result = await axios.get<SiteStats>(`${Config.API_URL}/stats`);
+      const result = await axios.get<SiteStats>(`${config.apiUrl}/${config.statsPath}`);
 
       return ok(result.data);
     } catch (error) {

--- a/src/core/api/StatsApi.ts
+++ b/src/core/api/StatsApi.ts
@@ -15,7 +15,7 @@ const config = getConfig()?.publicRuntimeConfig;
 export class StatsApi {
   static async getStats(): AppResult<SiteStats> {
     try {
-      const result = await axios.get<SiteStats>(`${config.apiUrl}/${config.statsPath}`);
+      const result = await axios.get<SiteStats>(`${config.apiUrl}/stats}`);
 
       return ok(result.data);
     } catch (error) {

--- a/src/core/api/StatsApi.ts
+++ b/src/core/api/StatsApi.ts
@@ -10,7 +10,7 @@ export type SiteStats = {
   numUsers: number;
 };
 
-const { config } = getConfig();
+const config = getConfig()?.publicRuntimeConfig;
 
 export class StatsApi {
   static async getStats(): AppResult<SiteStats> {

--- a/src/core/authentication/AuthApi.ts
+++ b/src/core/authentication/AuthApi.ts
@@ -3,7 +3,7 @@ import { ok } from "neverthrow";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 type TokenRes = {
   accessToken: string;

--- a/src/core/authentication/AuthApi.ts
+++ b/src/core/authentication/AuthApi.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+import getConfig from "next/config";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 type TokenRes = {
   accessToken: string;
@@ -10,12 +12,12 @@ type TokenRes = {
 export class AuthApi {
   static async refreshToken(cookie?: string): AppResult<string> {
     try {
-      let config: AxiosRequestConfig = {
+      let requestConfig: AxiosRequestConfig = {
         withCredentials: true,
       };
 
       if (cookie) {
-        config = {
+        requestConfig = {
           ...config,
           headers: {
             cookie: cookie,
@@ -24,8 +26,8 @@ export class AuthApi {
       }
 
       const res = await axios.get<TokenRes>(
-        `${Config.API_URL}/auth/refresh`,
-        config
+        `${config.apiUrl}/auth/refresh`,
+        requestConfig
       );
 
       return ok(res.data.accessToken);
@@ -36,7 +38,7 @@ export class AuthApi {
 
   static async setSessionCookie(): Promise<void> {
     await axios.post(
-      `${Config.API_URL}/initSession`,
+      `${config.apiUrl}/initSession`,
       {},
       { withCredentials: true }
     );
@@ -45,7 +47,7 @@ export class AuthApi {
   static async signOut(): Promise<void> {
     try {
       await axios.post(
-        `${Config.API_URL}/auth/signout`,
+        `${config.apiUrl}/auth/signout`,
         {},
         {
           withCredentials: true,

--- a/src/core/global/GlobalStore.ts
+++ b/src/core/global/GlobalStore.ts
@@ -53,7 +53,7 @@ const globalStore = createSlice({
 
 const persistConfig: PersistConfig<GlobalState> = {
   key: "globalStore",
-  storage,
+  storage: storage,
   whitelist: ["acceptedCookieConcent"],
 };
 

--- a/src/core/layout/defaultheader/components/SignInnButton.tsx
+++ b/src/core/layout/defaultheader/components/SignInnButton.tsx
@@ -1,3 +1,4 @@
+import getConfig from "next/config";
 import { FC } from "react";
 import { FaSteam } from "react-icons/fa";
 import { Config, Dimensions } from "../../../../constants/Constants";
@@ -5,6 +6,7 @@ import { useAnalytics } from "../../../../utils/Analytics";
 
 export const SignInnButton: FC = () => {
   const { event } = useAnalytics();
+  const { publicRuntimeConfig } = getConfig();
 
   function onSignInClick() {
     event({
@@ -18,7 +20,7 @@ export const SignInnButton: FC = () => {
       <div className="steam-login-wrapper">
         <a
           className="steam-login"
-          href={Config.SIGN_IN_URL}
+          href={publicRuntimeConfig.signInUrl}
           rel="nofollow"
           onClick={onSignInClick}
         >

--- a/src/core/layout/defaultheader/components/SignInnButton.tsx
+++ b/src/core/layout/defaultheader/components/SignInnButton.tsx
@@ -4,9 +4,10 @@ import { FaSteam } from "react-icons/fa";
 import { Config, Dimensions } from "../../../../constants/Constants";
 import { useAnalytics } from "../../../../utils/Analytics";
 
+const config = getConfig()?.publicRuntimeConfig;
+
 export const SignInnButton: FC = () => {
   const { event } = useAnalytics();
-  const { publicRuntimeConfig } = getConfig();
 
   function onSignInClick() {
     event({
@@ -20,7 +21,7 @@ export const SignInnButton: FC = () => {
       <div className="steam-login-wrapper">
         <a
           className="steam-login"
-          href={publicRuntimeConfig.signInUrl}
+          href={config.apiUrl + "/auth/steam"}
           rel="nofollow"
           onClick={onSignInClick}
         >

--- a/src/favorites/data/FavoriteApi.ts
+++ b/src/favorites/data/FavoriteApi.ts
@@ -5,7 +5,7 @@ import { Config } from "../../constants/Constants";
 import { Favorite } from "../models/Favorite";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
-const { config } = getConfig();
+const config = getConfig()?.publicRuntimeConfig;
 
 export const getUserFavorites = async (
   token: string

--- a/src/favorites/data/FavoriteApi.ts
+++ b/src/favorites/data/FavoriteApi.ts
@@ -1,7 +1,6 @@
 import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { Favorite } from "../models/Favorite";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 

--- a/src/favorites/data/FavoriteApi.ts
+++ b/src/favorites/data/FavoriteApi.ts
@@ -1,14 +1,17 @@
+import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
 import { Favorite } from "../models/Favorite";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
+const { config } = getConfig();
+
 export const getUserFavorites = async (
   token: string
 ): AppResult<Favorite[]> => {
   try {
-    const res = await axios.get<Favorite[]>(`${Config.API_URL}/favorites`, {
+    const res = await axios.get<Favorite[]>(`${config.apiUrl}/favorites`, {
       headers: { Authorization: token },
     });
     const favoritedNades = res.data;
@@ -21,7 +24,7 @@ export const getUserFavorites = async (
 export class FavoriteApi {
   static async getUserFavorites(token: string): AppResult<Favorite[]> {
     try {
-      const res = await axios.get<Favorite[]>(`${Config.API_URL}/favorites`, {
+      const res = await axios.get<Favorite[]>(`${config.apiUrl}/favorites`, {
         headers: { Authorization: token },
       });
       const favoritedNades = res.data;
@@ -34,7 +37,7 @@ export class FavoriteApi {
   static async favorite(nadeId: string, token: string): AppResult<Favorite> {
     try {
       const res = await axios.post(
-        `${Config.API_URL}/favorites/${nadeId}`,
+        `${config.apiUrl}/favorites/${nadeId}`,
         undefined,
         {
           headers: { Authorization: token },
@@ -52,7 +55,7 @@ export class FavoriteApi {
     token: string
   ): AppResult<boolean> {
     try {
-      await axios.delete(`${Config.API_URL}/favorites/${favoriteId}`, {
+      await axios.delete(`${config.apiUrl}/favorites/${favoriteId}`, {
         headers: { Authorization: token },
       });
       return ok(true);

--- a/src/nade/components/comments/CommentSubmit.tsx
+++ b/src/nade/components/comments/CommentSubmit.tsx
@@ -1,3 +1,4 @@
+import getConfig from "next/config";
 import { FC, useState, memo } from "react";
 import { useGetOrUpdateToken } from "../../../core/authentication/useGetToken";
 import { NadeCommentApi, NadeComment } from "../../data/NadeCommentApi";
@@ -15,6 +16,7 @@ export const CommentSubmit: FC<Props> = memo(
     const { colors } = useTheme();
     const isSignedIn = useIsSignedIn();
     const getToken = useGetOrUpdateToken();
+    const { config } = getConfig();
 
     const [loading, setLoading] = useState(false);
     const [message, setMessage] = useState("");
@@ -58,7 +60,7 @@ export const CommentSubmit: FC<Props> = memo(
           <div className="comment-sign-in">
             <p>Do you want to comment on this nade?</p>
             <div>
-              <a href={Config.SIGN_IN_URL}>Sign in with steam</a>
+              <a href={config.apiUrl + "/auth/steam"}>Sign in with steam</a>
             </div>
           </div>
         )}

--- a/src/nade/components/comments/CommentSubmit.tsx
+++ b/src/nade/components/comments/CommentSubmit.tsx
@@ -4,7 +4,7 @@ import { useGetOrUpdateToken } from "../../../core/authentication/useGetToken";
 import { NadeCommentApi, NadeComment } from "../../data/NadeCommentApi";
 import { useIsSignedIn } from "../../../core/authentication/useIsSignedIn";
 import { useTheme } from "../../../core/settings/SettingsHooks";
-import { Config, Dimensions } from "../../../constants/Constants";
+import { Dimensions } from "../../../constants/Constants";
 
 const config = getConfig()?.publicRuntimeConfig;
 

--- a/src/nade/components/comments/CommentSubmit.tsx
+++ b/src/nade/components/comments/CommentSubmit.tsx
@@ -6,6 +6,8 @@ import { useIsSignedIn } from "../../../core/authentication/useIsSignedIn";
 import { useTheme } from "../../../core/settings/SettingsHooks";
 import { Config, Dimensions } from "../../../constants/Constants";
 
+const config = getConfig()?.publicRuntimeConfig;
+
 type Props = {
   nadeId: string;
   onCommentSubmitted: (newComment: NadeComment) => void;
@@ -16,7 +18,6 @@ export const CommentSubmit: FC<Props> = memo(
     const { colors } = useTheme();
     const isSignedIn = useIsSignedIn();
     const getToken = useGetOrUpdateToken();
-    const { config } = getConfig();
 
     const [loading, setLoading] = useState(false);
     const [message, setMessage] = useState("");

--- a/src/nade/data/NadeApi.ts
+++ b/src/nade/data/NadeApi.ts
@@ -1,7 +1,6 @@
 import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { CsgoMap } from "../../map/models/CsGoMap";
 import { GfycatData } from "../models/GfycatData";
 import {

--- a/src/nade/data/NadeApi.ts
+++ b/src/nade/data/NadeApi.ts
@@ -1,3 +1,4 @@
+import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
@@ -12,11 +13,13 @@ import {
 } from "../models/Nade";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
+const { config } = getConfig()?.publicRuntimeConfig;
+
 export class NadeApi {
   static async slugIsFree(slug: string): Promise<boolean> {
     try {
       const res = await axios.get<boolean>(
-        `${Config.API_URL}/nades/${slug}/checkslug`
+        `${config.apiUrl}/nades/${slug}/checkslug`
       );
 
       const isFree = res.data;
@@ -28,7 +31,7 @@ export class NadeApi {
 
   static async getAll(): AppResult<NadeLight[]> {
     try {
-      const res = await axios.get(`${Config.API_URL}/nades`);
+      const res = await axios.get(`${config.apiUrl}/nades`);
       const nades = res.data as NadeLight[];
 
       return ok(nades);
@@ -40,7 +43,7 @@ export class NadeApi {
   static async getPending(token: string): AppResult<NadeLight[]> {
     try {
       const res = await axios.get<NadeLight[]>(
-        `${Config.API_URL}/nades/pending`,
+        `${config.apiUrl}/nades/pending`,
         {
           headers: { Authorization: token },
         }
@@ -56,7 +59,7 @@ export class NadeApi {
   static async getDeclined(token: string): AppResult<NadeLight[]> {
     try {
       const res = await axios.get<NadeLight[]>(
-        `${Config.API_URL}/nades/declined`,
+        `${config.apiUrl}/nades/declined`,
         {
           headers: { Authorization: token },
         }
@@ -72,7 +75,7 @@ export class NadeApi {
   static async getByMap(mapName: CsgoMap): AppResult<NadeLight[]> {
     try {
       const res = await axios.get<NadeLight[]>(
-        `${Config.API_URL}/nades/map/${mapName}`
+        `${config.apiUrl}/nades/map/${mapName}`
       );
       const nades = res.data;
 
@@ -84,7 +87,7 @@ export class NadeApi {
 
   static async byId(id: string): AppResult<Nade> {
     try {
-      const res = await axios.get(`${Config.API_URL}/nades/${id}`, {
+      const res = await axios.get(`${config.apiUrl}/nades/${id}`, {
         withCredentials: true,
       });
 
@@ -97,7 +100,7 @@ export class NadeApi {
 
   static async byUser(steamId: string): AppResult<NadeLight[]> {
     try {
-      const res = await axios.get(`${Config.API_URL}/nades/user/${steamId}`);
+      const res = await axios.get(`${config.apiUrl}/nades/user/${steamId}`);
       const nades = res.data as NadeLight[];
       return ok(nades);
     } catch (error) {
@@ -107,7 +110,7 @@ export class NadeApi {
 
   static async byNadeIdList(nadeIds: string[]): AppResult<NadeLight[]> {
     try {
-      const res = await axios.post(`${Config.API_URL}/nades/list`, {
+      const res = await axios.post(`${config.apiUrl}/nades/list`, {
         nadeIds,
       });
       const nades = res.data as NadeLight[];
@@ -119,7 +122,7 @@ export class NadeApi {
 
   static async save(nadeBody: NadeCreateBody, token: string): AppResult<Nade> {
     try {
-      const res = await axios.post(`${Config.API_URL}/nades`, nadeBody, {
+      const res = await axios.post(`${config.apiUrl}/nades`, nadeBody, {
         headers: { Authorization: token },
       });
       const nade = res.data as Nade;
@@ -136,7 +139,7 @@ export class NadeApi {
   ): AppResult<Nade> {
     try {
       const res = await axios.put(
-        `${Config.API_URL}/nades/${nadeId}`,
+        `${config.apiUrl}/nades/${nadeId}`,
         updateFields,
         {
           headers: { Authorization: token },
@@ -153,7 +156,7 @@ export class NadeApi {
 
   static async delete(nadeId: string, token: string): AppResult<boolean> {
     try {
-      await axios.delete(`${Config.API_URL}/nades/${nadeId}`, {
+      await axios.delete(`${config.apiUrl}/nades/${nadeId}`, {
         headers: { Authorization: token },
       });
 
@@ -166,7 +169,7 @@ export class NadeApi {
   static async registerView(id: string): Promise<void> {
     try {
       await axios.post(
-        `${Config.API_URL}/nades/${id}/countView`,
+        `${config.apiUrl}/nades/${id}/countView`,
         {},
         {
           withCredentials: true,
@@ -182,7 +185,7 @@ export class NadeApi {
   ): AppResult<Nade> {
     try {
       const res = await axios.patch(
-        `${Config.API_URL}/nades/${nadeId}/status`,
+        `${config.apiUrl}/nades/${nadeId}/status`,
         updates,
         {
           headers: { Authorization: token },
@@ -203,7 +206,7 @@ export class NadeApi {
   ): AppResult<Nade> {
     try {
       const res = await axios.patch(
-        `${Config.API_URL}/nades/${nadeId}/setuser/${steamId}`,
+        `${config.apiUrl}/nades/${nadeId}/setuser/${steamId}`,
         undefined,
         {
           headers: {
@@ -227,7 +230,7 @@ export class NadeApi {
   ): AppResult<Nade> {
     try {
       const result = await axios.patch(
-        `${Config.API_URL}/nades/${nadeId}/year/${year}`,
+        `${config.apiUrl}/nades/${nadeId}/year/${year}`,
         {},
         {
           headers: {
@@ -246,7 +249,7 @@ export class NadeApi {
 
   static async validateGfycat(gfyIdOrUrl: string): AppResult<GfycatData> {
     try {
-      const res = await axios.post(`${Config.API_URL}/nades/validateGfycat`, {
+      const res = await axios.post(`${config.apiUrl}/nades/validateGfycat`, {
         gfycatIdOrUrl: gfyIdOrUrl,
       });
       const gfycatData = res.data as GfycatData;

--- a/src/nade/data/NadeApi.ts
+++ b/src/nade/data/NadeApi.ts
@@ -13,7 +13,7 @@ import {
 } from "../models/Nade";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 export class NadeApi {
   static async slugIsFree(slug: string): Promise<boolean> {

--- a/src/nade/data/NadeCommentApi.ts
+++ b/src/nade/data/NadeCommentApi.ts
@@ -1,7 +1,9 @@
+import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 export type NadeComment = {
   avatar: string;
@@ -27,7 +29,7 @@ export class NadeCommentApi {
   static async getCommentsForNade(nadeId: string): AppResult<NadeComment[]> {
     try {
       const res = await axios.get<NadeComment[]>(
-        `${Config.API_URL}/nades/${nadeId}/comments`
+        `${config.apiUrl}/nades/${nadeId}/comments`
       );
 
       return ok(res.data);
@@ -42,7 +44,7 @@ export class NadeCommentApi {
   ): AppResult<NadeComment> {
     try {
       const res = await axios.post<NadeComment>(
-        `${Config.API_URL}/nades/${comment.nadeId}/comments`,
+        `${config.apiUrl}/nades/${comment.nadeId}/comments`,
         comment,
         {
           headers: { Authorization: token },
@@ -62,7 +64,7 @@ export class NadeCommentApi {
   ): AppResult<NadeComment> {
     try {
       const res = await axios.patch<NadeComment>(
-        `${Config.API_URL}/nades/${nadeId}/comments/${commentUpdate.id}`,
+        `${config.apiUrl}/nades/${nadeId}/comments/${commentUpdate.id}`,
         commentUpdate,
         {
           headers: { Authorization: token },
@@ -81,7 +83,7 @@ export class NadeCommentApi {
   ): AppResult<boolean> {
     try {
       await axios.delete(
-        `${Config.API_URL}/nades/${nadeId}/comments/${commentId}`,
+        `${config.apiUrl}/nades/${nadeId}/comments/${commentId}`,
         {
           headers: { Authorization: token },
         }

--- a/src/nade/data/NadeCommentApi.ts
+++ b/src/nade/data/NadeCommentApi.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { ok } from "neverthrow";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 export type NadeComment = {
   avatar: string;

--- a/src/notification/data/NotificationApi.ts
+++ b/src/notification/data/NotificationApi.ts
@@ -5,7 +5,7 @@ import { Notification } from "../models/Notification";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 
-const { config } = getConfig();
+const config = getConfig()?.publicRuntimeConfig;
 
 export class NotificationApi {
   static async getNotifications(token: string): AppResult<Notification[]> {

--- a/src/notification/data/NotificationApi.ts
+++ b/src/notification/data/NotificationApi.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Notification } from "../../models/Notification";
+import { Notification } from "../models/Notification";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 

--- a/src/notification/data/NotificationApi.ts
+++ b/src/notification/data/NotificationApi.ts
@@ -3,12 +3,15 @@ import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
 import { Notification } from "../models/Notification";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+import getConfig from "next/config";
+
+const { config } = getConfig();
 
 export class NotificationApi {
   static async getNotifications(token: string): AppResult<Notification[]> {
     try {
       const res = await axios.get<Notification[]>(
-        `${Config.API_URL}/notifications`,
+        `${config.apiUrl}/notifications`,
         {
           headers: { Authorization: token },
         }
@@ -22,7 +25,7 @@ export class NotificationApi {
   static async markAsViewed(id: string, token: string): Promise<void> {
     try {
       await axios.patch(
-        `${Config.API_URL}/notifications/${id}/viewed`,
+        `${config.apiUrl}/notifications/${id}/viewed`,
         {},
         {
           headers: { Authorization: token },

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
 import { NextApiRequest, NextApiResponse } from "next";
+import getConfig from "next/config";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 const CsGoMaps = {
   dust2: "Dust2",
@@ -23,7 +26,7 @@ function mapsList() {
 }
 
 const SITE_ROOT = "https://www.csgonades.com";
-const API_SOURCE = "https://api.csgonades.com";
+const API_SOURCE = config.apiUrl;
 
 const createSitemap = async () => {
   let xml = "";

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { NextApiRequest, NextApiResponse } from "next";
 import getConfig from "next/config";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 const CsGoMaps = {
   dust2: "Dust2",

--- a/src/pages/nades/[...slug].tsx
+++ b/src/pages/nades/[...slug].tsx
@@ -29,7 +29,10 @@ export const getServerSideProps: GetServerSideProps = async ({
   query,
   res,
 }) => {
-  const [nadeId, operation] = query.slug;
+  // not sure about this, without it, i'm getting TS2488.
+  // "solution" taken from:
+  // https://github.com/Microsoft/TypeScript/issues/12707
+  const [nadeId, operation] = query.slug!;
 
   if (!nadeId || !operation) {
     res.statusCode = 404;

--- a/src/reports/data/ReportApi.ts
+++ b/src/reports/data/ReportApi.ts
@@ -1,7 +1,6 @@
 import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
-import { Config } from "../../constants/Constants";
 import { Report, ReportAddDto } from "../models/Report";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 

--- a/src/reports/data/ReportApi.ts
+++ b/src/reports/data/ReportApi.ts
@@ -1,13 +1,16 @@
+import getConfig from "next/config";
 import axios from "axios";
 import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
 import { Report, ReportAddDto } from "../models/Report";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
+const { config } = getConfig();
+
 export class ReportApi {
   static async getAll(token: string): AppResult<Report[]> {
     try {
-      const res = await axios.get<Report[]>(`${Config.API_URL}/reports`, {
+      const res = await axios.get<Report[]>(`${config.apiUrl}/reports`, {
         headers: { Authorization: token },
       });
       const reports = res.data;
@@ -20,7 +23,7 @@ export class ReportApi {
 
   static async add(data: ReportAddDto): AppResult<Report> {
     try {
-      const res = await axios.post<Report>(`${Config.API_URL}/reports`, data);
+      const res = await axios.post<Report>(`${config.apiUrl}/reports`, data);
 
       return ok(res.data);
     } catch (error) {
@@ -30,7 +33,7 @@ export class ReportApi {
 
   static async delete(id: string, token: string): AppResult<boolean> {
     try {
-      await axios.delete(`${Config.API_URL}/reports/${id}`, {
+      await axios.delete(`${config.apiUrl}/reports/${id}`, {
         headers: { Authorization: token },
       });
       return ok(true);

--- a/src/reports/data/ReportApi.ts
+++ b/src/reports/data/ReportApi.ts
@@ -5,7 +5,7 @@ import { Config } from "../../constants/Constants";
 import { Report, ReportAddDto } from "../models/Report";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 
-const { config } = getConfig();
+const config = getConfig()?.publicRuntimeConfig;
 
 export class ReportApi {
   static async getAll(token: string): AppResult<Report[]> {

--- a/src/users/data/UserApi.ts
+++ b/src/users/data/UserApi.ts
@@ -5,7 +5,7 @@ import { User, UserUpdateDTO } from "../models/User";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 
-const { config } = getConfig()?.publicRuntimeConfig;
+const config = getConfig()?.publicRuntimeConfig;
 
 export class UserApi {
   static fetchSelf = async (token: string): AppResult<User> => {

--- a/src/users/data/UserApi.ts
+++ b/src/users/data/UserApi.ts
@@ -3,11 +3,14 @@ import { ok } from "neverthrow";
 import { Config } from "../../constants/Constants";
 import { User, UserUpdateDTO } from "../models/User";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
+import getConfig from "next/config";
+
+const { config } = getConfig()?.publicRuntimeConfig;
 
 export class UserApi {
   static fetchSelf = async (token: string): AppResult<User> => {
     try {
-      const res = await axios.get(`${Config.API_URL}/users/self`, {
+      const res = await axios.get(`${config.apiUrl}/users/self`, {
         headers: { Authorization: token },
       });
       const user = res.data as User;
@@ -22,13 +25,13 @@ export class UserApi {
     token?: string
   ): AppResult<User> => {
     try {
-      let config = {};
+      let requestConfig = {};
 
       if (token) {
-        config = { headers: { Authorization: token } };
+        requestConfig = { headers: { Authorization: token } };
       }
 
-      const res = await axios.get(`${Config.API_URL}/users/${steamId}`, config);
+      const res = await axios.get(`${config.apiUrl}/users/${steamId}`, requestConfig);
       const user = res.data as User;
       return ok(user);
     } catch (error) {
@@ -44,7 +47,7 @@ export class UserApi {
   ): AppResult<User[]> => {
     try {
       const res = await axios.get(
-        `${Config.API_URL}/users?page=${page}&limit=${limit}&sortActive=${sortByActivity}`,
+        `${config.apiUrl}/users?page=${page}&limit=${limit}&sortActive=${sortByActivity}`,
         {
           headers: { Authorization: token },
         }
@@ -63,7 +66,7 @@ export class UserApi {
   ): AppResult<User> => {
     try {
       const res = await axios.patch(
-        `${Config.API_URL}/users/${steamId}`,
+        `${config.apiUrl}/users/${steamId}`,
         updatedUser,
         {
           headers: { Authorization: token },

--- a/src/users/data/UserApi.ts
+++ b/src/users/data/UserApi.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { ok } from "neverthrow";
-import { User, UserUpdateDTO } from "../../models/User";
+import { User, UserUpdateDTO } from "../models/User";
 import { AppResult, extractApiError } from "../../utils/ErrorUtil";
 import getConfig from "next/config";
 


### PR DESCRIPTION
Since you based it on nextjs, I thought it would be neat to use [nextjs' config](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) in combination with their [dotenv style environment variables](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)

let me know what you think of this solution 

--- 
I saw you already implemented a solution for all of us without backend server at localhost. 
but, as discussed in discord, I'm PR'ing mine also, because why not :D
you can decide whichever way you want to go ;)